### PR TITLE
Update release links to v2.0.26

### DIFF
--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -1070,9 +1070,9 @@
                                         <div class="my-4">
                                             <div class="system-text">WINDOWS 10+</div>
                                         </div>
-                                        <a href="https://github.com/GingerPrivacy/GingerWallet/releases/download/v2.0.25/Ginger-2.0.25.msi" target="_blank" class="btn btn-primary w-100" data-lang="download">Download</a>
+                                        <a href="https://github.com/GingerPrivacy/GingerWallet/releases/download/v2.0.26/Ginger-2.0.26.msi" target="_blank" class="btn btn-primary w-100" data-lang="download">Download</a>
                                         <div class="small-text mt-4">
-                                            .msi <span class="float-end"><a href="https://github.com/GingerPrivacy/GingerWallet/releases/download/v2.0.25/Ginger-2.0.25.msi.asc" target="_blank" data-lang="signature">signature</a></span>
+                                            .msi <span class="float-end"><a href="https://github.com/GingerPrivacy/GingerWallet/releases/download/v2.0.26/Ginger-2.0.26.msi.asc" target="_blank" data-lang="signature">signature</a></span>
                                         </div>
                                     </div>
                                 </div>
@@ -1082,9 +1082,9 @@
                                         <div class="my-4">
                                             <div class="system-text">MACOS 12.0+ INTEL</div>
                                         </div>
-                                        <a href="https://github.com/GingerPrivacy/GingerWallet/releases/download/v2.0.25/Ginger-2.0.25.dmg" target="_blank" class="btn btn-primary w-100" data-lang="download">Download</a>
+                                        <a href="https://github.com/GingerPrivacy/GingerWallet/releases/download/v2.0.26/Ginger-2.0.26.dmg" target="_blank" class="btn btn-primary w-100" data-lang="download">Download</a>
                                         <div class="small-text mt-4">
-                                            .dmg <span class="float-end"><a href="https://github.com/GingerPrivacy/GingerWallet/releases/download/v2.0.25/Ginger-2.0.25.dmg.asc" target="_blank" data-lang="signature">signature</a></span>
+                                            .dmg <span class="float-end"><a href="https://github.com/GingerPrivacy/GingerWallet/releases/download/v2.0.26/Ginger-2.0.26.dmg.asc" target="_blank" data-lang="signature">signature</a></span>
                                         </div>
                                     </div>
                                 </div>
@@ -1094,9 +1094,9 @@
                                         <div class="my-4">
                                             <div class="system-text">MACOS 12.0+ M1, M2</div>
                                         </div>
-                                        <a href="https://github.com/GingerPrivacy/GingerWallet/releases/download/v2.0.25/Ginger-2.0.25-arm64.dmg" target="_blank" class="btn btn-primary w-100" data-lang="download">Download</a>
+                                        <a href="https://github.com/GingerPrivacy/GingerWallet/releases/download/v2.0.26/Ginger-2.0.26-arm64.dmg" target="_blank" class="btn btn-primary w-100" data-lang="download">Download</a>
                                         <div class="small-text mt-4">
-                                            .dmg <span class="float-end"><a href="https://github.com/GingerPrivacy/GingerWallet/releases/download/v2.0.25/Ginger-2.0.25-arm64.dmg.asc" target="_blank" data-lang="signature">signature</a></span>
+                                            .dmg <span class="float-end"><a href="https://github.com/GingerPrivacy/GingerWallet/releases/download/v2.0.26/Ginger-2.0.26-arm64.dmg.asc" target="_blank" data-lang="signature">signature</a></span>
                                         </div>
                                     </div>
                                 </div>
@@ -1106,9 +1106,9 @@
                                         <div class="my-4">
                                             <div class="system-text">UBUNTU / DEBIAN</div>
                                         </div>
-                                        <a href="https://github.com/GingerPrivacy/GingerWallet/releases/download/v2.0.25/Ginger-2.0.25.deb" target="_blank" class="btn btn-primary w-100" data-lang="download">Download</a>
+                                        <a href="https://github.com/GingerPrivacy/GingerWallet/releases/download/v2.0.26/Ginger-2.0.26.deb" target="_blank" class="btn btn-primary w-100" data-lang="download">Download</a>
                                         <div class="small-text mt-4">
-                                            .deb <span class="float-end"><a href="https://github.com/GingerPrivacy/GingerWallet/releases/download/v2.0.25/Ginger-2.0.25.deb.asc" target="_blank" data-lang="signature">signature</a></span>
+                                            .deb <span class="float-end"><a href="https://github.com/GingerPrivacy/GingerWallet/releases/download/v2.0.26/Ginger-2.0.26.deb.asc" target="_blank" data-lang="signature">signature</a></span>
                                         </div>
                                     </div>
                                 </div>
@@ -1118,9 +1118,9 @@
                                         <div class="my-4">
                                             <div class="system-text">OTHER LINUX</div>
                                         </div>
-                                        <a href="https://github.com/GingerPrivacy/GingerWallet/releases/download/v2.0.25/Ginger-2.0.25.tar.gz" target="_blank" class="btn btn-primary w-100" data-lang="download">Download</a>
+                                        <a href="https://github.com/GingerPrivacy/GingerWallet/releases/download/v2.0.26/Ginger-2.0.26.tar.gz" target="_blank" class="btn btn-primary w-100" data-lang="download">Download</a>
                                         <div class="small-text mt-4">
-                                            .tar.gz <span class="float-end"><a href="https://github.com/GingerPrivacy/GingerWallet/releases/download/v2.0.25/Ginger-2.0.25.tar.gz.asc" target="_blank" data-lang="signature">signature</a></span>
+                                            .tar.gz <span class="float-end"><a href="https://github.com/GingerPrivacy/GingerWallet/releases/download/v2.0.26/Ginger-2.0.26.tar.gz.asc" target="_blank" data-lang="signature">signature</a></span>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
## Summary

Updates the Ginger Wallet website download and signature links from v2.0.25 to v2.0.26.

## Why

Ginger Wallet v2.0.26 is being prepared for release, so the website needs to point users to the new release artifacts.

## User impact

Once the release is published and this change is deployed, visitors will download v2.0.26 for:

- Windows
- macOS Intel
- macOS Apple Silicon
- Ubuntu / Debian
- Other Linux

The matching signature links are updated as well.

## Validation

- `git diff --check`
- Confirmed all 10 download and signature links reference v2.0.26.
- Confirmed no v2.0.25 release links remain in `wwwroot/index.html`.
